### PR TITLE
Add GetAllCities endpoint to CityController

### DIFF
--- a/FitCircleAPI/Controllers/CityController.cs
+++ b/FitCircleAPI/Controllers/CityController.cs
@@ -1,5 +1,6 @@
 ﻿using Application.Features.Cities.Commands.Create;
 using Application.Features.Cities.Dtos;
+using Application.Features.Cities.Queries;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -24,6 +25,18 @@ namespace FitCircleAPI.Controllers
             var commandRequest = new CreateCityCommandRequest(dto);
             var city = await _mediatr.Send(commandRequest);
             return CreatedAtAction(nameof(Create), city);
+        }
+
+        [HttpGet]
+
+        public async Task<IActionResult> GetAllCities()
+        {
+            var cities = _mediatr.Send(new GetAllCitiesQueryRequest()); 
+            if(cities != null)
+            {
+                return Ok(cities);
+            }
+            return BadRequest();
         }
     }
 }


### PR DESCRIPTION
Updated `CityController.cs` to include a new HTTP GET endpoint for retrieving all cities. Added a using directive for `Application.Features.Cities.Queries` and implemented the `GetAllCities` method, which queries the cities and returns an appropriate response based on the result.