### PR TITLE
Add city deletion feature and mapping configurations

### DIFF
--- a/Core/Application/Application.csproj
+++ b/Core/Application/Application.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Features\Cities\Commands\Delete\" />
+  </ItemGroup>
+
 </Project>

--- a/Core/Application/Common/Mapping/CityProfile.cs
+++ b/Core/Application/Common/Mapping/CityProfile.cs
@@ -1,0 +1,13 @@
+﻿using Application.Features.Cities.Dtos;
+using AutoMapper;
+
+namespace Application.Common.Mapping
+{
+    public class CityProfile : Profile
+    {
+        public CityProfile()
+        {
+            CreateMap<City, CityDto>();
+        }
+    }
+}

--- a/Core/Application/Features/Cities/Dtos/DeleteCityDto.cs
+++ b/Core/Application/Features/Cities/Dtos/DeleteCityDto.cs
@@ -1,0 +1,7 @@
+﻿namespace Application.Features.Cities.Dtos
+{
+    public class DeleteCityDto
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/Core/Application/Features/Cities/Queries/GetAllCitiesQueryHandler.cs
+++ b/Core/Application/Features/Cities/Queries/GetAllCitiesQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Application.Abstracts.Repositories.Cities;
 using Application.Features.Cities.Dtos;
+using AutoMapper;
 using MediatR;
 
 namespace Application.Features.Cities.Queries
@@ -7,16 +8,18 @@ namespace Application.Features.Cities.Queries
     public class GetAllCitiesQueryHandler : IRequestHandler<GetAllCitiesQueryRequest, List<CityDto>>
     {
         readonly ICityReadRepository _readRepository;
+        readonly IMapper _mapper;
 
-        public GetAllCitiesQueryHandler(ICityReadRepository readRepository)
+        public GetAllCitiesQueryHandler(ICityReadRepository readRepository, IMapper mapper)
         {
             _readRepository = readRepository;
+            _mapper = mapper;
         }
 
         public async Task<List<CityDto>> Handle(GetAllCitiesQueryRequest request, CancellationToken cancellationToken)
         {
             var cities = await _readRepository.GetAllAsync(cancellationToken).ConfigureAwait(false);
-            return new();
-        }
+            return _mapper.Map<List<CityDto>>(cities);
+        }   
     }
 }


### PR DESCRIPTION
- Updated `Application.csproj` to include a folder for the delete cities feature.
- Modified `GetAllCitiesQueryHandler` to use `IMapper` for converting city entities to `CityDto`.
- Added `CityProfile` for mapping between `City` and `CityDto`.
- Created `DeleteCityDto` to represent the city ID for deletion.